### PR TITLE
Started transactional data gathering

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,12 +13,13 @@ const RootStack = createStackNavigator({
 	Home: {
 		screen: Tabs,
 		navigationOptions: {
-			header: null
+			header: null,
 		}
 	},
 	Settings: {
 		screen: Settings
 	},
+
 },
 {
 	defaultNavigationOptions: {
@@ -42,7 +43,8 @@ const AuthStack = (authorized) => createStackNavigator({
 	Home: {
 		screen: RootStack,
 		navigationOptions: {
-			header: null
+			header: null,
+			gesturesEnabled: false
 		}
 	},
 	Login: {
@@ -107,6 +109,9 @@ export default class App extends React.Component {
     })
     EventRegister.addEventListener('logout', (data) => {
         this.loadNetwork();
+    })
+    EventRegister.addEventListener('load_main', (data) => {
+        this.setState({ authorized: true, checkedAuth: true });
     })
 	}
 

--- a/auth/index.js
+++ b/auth/index.js
@@ -2,6 +2,7 @@ import { AsyncStorage } from "react-native";
 import { SecureStore } from "expo";
 import { EventRegister } from 'react-native-event-listeners';
 import globals from "../globals.js";
+import { getData } from '../import_data.js';
 
 function timeout(ms, promise) {
   return new Promise(function(resolve, reject) {
@@ -67,12 +68,21 @@ export const signIn = (user, pass) => new Promise((resolve,reject) => {
       catch (err) {
         reject("Username or password are incorrect");
       }
-      globals.TERM = data.term;
-      globals.NAME = data.name.split('+');
-      globals.SESSID = data.sessid;
+      globals["TERM"] = data.term;
+      globals["NAME"] = data.name.split('+');
+      globals["SESSID"] = data.sessid;
       await SecureStore.setItemAsync("username", user);
       await SecureStore.setItemAsync("password", pass);
-      if (body.ok) resolve(body);
+      if (body.ok) {
+        try {
+          await getData(data.term);
+        }
+        catch (err) {
+          reject("Gathering data from SIS failed");
+        }
+        console.log(globals);
+        resolve(body);
+      }
       else reject("Unauthorized");
     }).catch((err) => {
       reject("Login failed")
@@ -80,5 +90,4 @@ export const signIn = (user, pass) => new Promise((resolve,reject) => {
   }).catch((err) => {
     reject("Failed to find Schedj Backend service", "Network Error");
   });
-  
 });

--- a/globals.js
+++ b/globals.js
@@ -1,5 +1,5 @@
 import env from './env.js';
-const server = 'http://129.161.53.28:8080';
+const server = 'http://192.168.1.173:8080';
 // const server = 'http://localhost:8080';
 
 export default {
@@ -7,9 +7,8 @@ export default {
 	ROUTES: {
 		login: server + '/login',
 		logout: server + '/logout',
-		handshake: server + '/verify_status'
-	},
-	TERM: '',
-	SESSID: '',
-	NAME: ''
+		handshake: server + '/verify_status',
+		address: server + '/address',
+		registration: server + '/feed/registration?term='
+	}
 }

--- a/import_data.js
+++ b/import_data.js
@@ -1,0 +1,11 @@
+import globals from "./globals.js";
+
+export const getData = (term) => {
+	var promises = [];
+	promises.push(fetch(globals.ROUTES.address)
+	.then(res=>res.json())
+	.then(resJson=> {
+		globals["ADDRESS"] = resJson;
+	}));
+	return Promise.all(promises);
+}

--- a/views/Login.js
+++ b/views/Login.js
@@ -16,6 +16,7 @@ import { RoundedCard, LoginView, SButton } from '../components';
 import { LoginStyle } from '../styles';
 import { LinearGradient } from 'expo';
 import { signIn } from '../auth';
+import { EventRegister } from 'react-native-event-listeners';
 import DropdownAlert from 'react-native-dropdownalert';
 
 function dismiss() {
@@ -33,7 +34,7 @@ export default class FeedScreen extends React.Component {
     this.setState({ loading: true });
     signIn(this.state.username, this.state.password)
       .then((valid) => {
-        nav('Home');
+        EventRegister.emit('load_main');
       }).catch((err, title) => {
         title = title ? title : "Authentication Error";
         this.dropdown.alertWithType('error', title, err);

--- a/views/Settings.js
+++ b/views/Settings.js
@@ -26,6 +26,7 @@ const styles = StyleSheet.create({
 })
 
 export default class SettingsScreen extends React.Component {
+  
 	static navigationOptions = { 
     title: "SETTINGS",
   }
@@ -35,7 +36,7 @@ export default class SettingsScreen extends React.Component {
       <View style={{ flex: 1, alignItems: 'center' }}>
         <View style={[styles.header]}>
           <Text style={[styles.name]}>{globals.NAME.join(' ')}</Text>
-          <Text style={[styles.location]}>San Fran</Text>
+          <Text style={[styles.location]}>{globals.ADDRESS.city}</Text>
         </View>
         <SButton onPress={()=>logout()} >Logout</SButton>
       </View>


### PR DESCRIPTION
This pieces together transactional data gathering on app start and load. This will be used for particular pieces of data that can be instantly pulled from SIS, but not entire pages. Here's what happens:
- The `globals.js` takes in all global data
- A new `import_data.js` file returns a Promise which finishes when all data is added to the globals
- Currently, this includes address information, name, session ID, and term.

Small change:
- Main view is not loaded as a modal but rather switched out